### PR TITLE
Adresses issues #18, #22, #23

### DIFF
--- a/add_and_upsample.py
+++ b/add_and_upsample.py
@@ -65,11 +65,14 @@ def add_red_and_blue_power(block, suffix_red, suffix_blue, suffix_out, f_red, po
     #IT 02/03/22: Commented line 86 to execute the code
     
     # extrapolate
-    inter_func_z = interp1d(z, np.log10(pk_tot), kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
-    pk_tot_ext_z = 10.0**inter_func_z(z_ext)
+    #inter_func_z = interp1d(z, np.nan_to_num(np.log10(pk_tot + 1.0), nan=0.0, posinf=0.0, neginf=0.0), kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
+    #pk_tot_ext_z = 10.0**inter_func_z(z_ext) - 1.0
+    # In redshift direction this seems to be more stable:
+    inter_func_z = interp1d(z, pk_tot, kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
+    pk_tot_ext_z = inter_func_z(z_ext)
     
-    inter_func_k = interp1d(np.log10(k), np.log10(pk_tot_ext_z), kind='linear', fill_value='extrapolate', bounds_error=False, axis=1)
-    pk_tot_ext = 10.0**inter_func_k(np.log10(k_ext))
+    inter_func_k = interp1d(np.log10(k), np.nan_to_num(np.log10(pk_tot_ext_z + 1.0), nan=0.0, posinf=0.0, neginf=0.0), kind='linear', fill_value='extrapolate', bounds_error=False, axis=1)
+    pk_tot_ext = 10.0**inter_func_k(np.log10(k_ext)) - 1.0
         
     # Introduce the sign convention back for the GI terms    
     if changed_sign:
@@ -83,11 +86,27 @@ def extrapolate_power(block, suffix_out, suffix_in, power_section, z_ext, k_ext,
     z = block[power_section + suffix_in, 'z']
     pk_in = block[power_section + suffix_in, 'p_k']
     
-    inter_func_z = interp1d(z, np.nan_to_num(np.log10(pk_in)), kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
-    pk_tot_ext_z = 10.0**inter_func_z(z_ext)
+    # For matter-intrinsic and galaxy-intrinsic, pk_tot will usually be negative (for A_IA > 0)
+    # If we're interpolating over log10(pk_tot) negative power is problematic
+    # Check to see if it is negative, and take the absolute value
+    if np.sum(pk_in)<0:
+        pk_in = pk_in * -1
+        changed_sign=True
+    else:
+        changed_sign=False
+    
+    #inter_func_z = interp1d(z, np.nan_to_num(np.log10(pk_in + 1.0), nan=0.0, posinf=0.0, neginf=0.0), kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
+    #pk_tot_ext_z = 10.0**inter_func_z(z_ext) - 1.0
+    # In redshift direction this seems to be more stable:
+    inter_func_z = interp1d(z, pk_in, kind='linear', fill_value=extrapolate_option, bounds_error=False, axis=0)
+    pk_tot_ext_z = inter_func_z(z_ext)
+    
+    inter_func_k = interp1d(np.log10(k), np.nan_to_num(np.log10(pk_tot_ext_z + 1.0), nan=0.0, posinf=0.0, neginf=0.0), kind='linear', fill_value='extrapolate', bounds_error=False, axis=1)
+    pk_tot_ext = 10.0**inter_func_k(np.log10(k_ext)) - 1.0
         
-    inter_func_k = interp1d(np.log10(k), np.nan_to_num(np.log10(pk_tot_ext_z)), kind='linear', fill_value='extrapolate', bounds_error=False, axis=1)
-    pk_tot_ext = 10.0**inter_func_k(np.log10(k_ext))
+    # Introduce the sign convention back for the GI terms
+    if changed_sign:
+        pk_tot_ext=pk_tot_ext*-1
         
     block.put_grid(power_section + suffix_out, 'z', z_ext, 'k_h', k_ext, 'p_k', pk_tot_ext)
  

--- a/example_ini_files/IA_comparison/create_mock_with_HaloModel_IA.ini
+++ b/example_ini_files/IA_comparison/create_mock_with_HaloModel_IA.ini
@@ -56,7 +56,7 @@ nmax = 0 ; 2580
 ; Now we have a power spectrum, it's time to define the
 ; dark matter halo mass function and halo bias
 [hmf_and_halo_bias]
-file = %(pipeline_path)s/hmf_and_hbf_tinker.py
+file = %(pipeline_path)s/hmf_and_hbf.py
 log_mass_min = %(logmassmin_def)s
 log_mass_max = %(logmassmax_def)s
 nmass = %(nmass_def)s

--- a/example_ini_files/config_example.ini
+++ b/example_ini_files/config_example.ini
@@ -77,7 +77,7 @@ nmax = 2580
 
 
 [hmf_and_halo_bias]
-file = ../ia_halo_model/dev/hmf_and_hbf_tinker.py
+file = ../ia_halo_model/dev/hmf_and_hbf.py
 log_mass_min = %(logmassmin_def)s
 log_mass_max = %(logmassmax_def)s
 nmass = %(nmass_def)s

--- a/example_ini_files/simulate_test.ini
+++ b/example_ini_files/simulate_test.ini
@@ -52,7 +52,7 @@ kmax = 1e8
 nmax = 0 ; 2580
 
 [hmf_and_halo_bias]
-file = %(pipeline_path)s/hmf_and_hbf_tinker.py
+file = %(pipeline_path)s/hmf_and_hbf.py
 log_mass_min = %(logmassmin_def)s
 log_mass_max = %(logmassmax_def)s
 nmass = %(nmass_def)s

--- a/hod_interface.py
+++ b/hod_interface.py
@@ -106,7 +106,7 @@ def setup(options):
     z_picked = options[option_section, 'z_median']
 
 
-    abs_mag_sun = options[option_section, 'abs_mag_sun']
+    #abs_mag_sun = options[option_section, 'abs_mag_sun']
 
     name = options.get_string(option_section, 'output_suffix', default='').lower()
     if name != '':
@@ -134,7 +134,7 @@ def setup(options):
             obs_simps[nb,jz] = np.logspace(obs_minz, obs_maxz, nobs)
             print ('%f %f %f' %(z_bins[nb,jz], obs_minz, obs_maxz))
     
-    return obs_simps, nbins, nz, nobs, z_bins, abs_mag_sun, log_mass_min, log_mass_max, nmass, mass, z_picked, hod_option, galaxy_bias_option, observable_option, observable_mode, suffix, suffix_params, observables_z
+    return obs_simps, nbins, nz, nobs, z_bins, log_mass_min, log_mass_max, nmass, mass, z_picked, hod_option, galaxy_bias_option, observable_option, observable_mode, suffix, suffix_params, observables_z
 
 
 
@@ -144,7 +144,7 @@ def execute(block, config):
     #It is the main workhorse of the code. The block contains the parameters and results of any 
     #earlier modules, and the config is what we loaded earlier.
 
-    obs_simps, nbins, nz, nobs, z_bins, abs_mag_sun, log_mass_min, log_mass_max, nmass, mass, z_picked, hod_option, galaxy_bias_option, observable_option, observable_mode, suffix0, suffix_params, observables_z = config
+    obs_simps, nbins, nz, nobs, z_bins, log_mass_min, log_mass_max, nmass, mass, z_picked, hod_option, galaxy_bias_option, observable_option, observable_mode, suffix0, suffix_params, observables_z = config
 
     #---- loading hod from the datablock ----#
 
@@ -354,7 +354,7 @@ def execute(block, config):
         obs_h = obs_range#/(h**2.) #note that the _h subscript avoids mixing h conventions while computing the clf_quantities
         obs_func_h = obs_func#*(h**5.)
         
-        mr_obs = cf.convert_to_magnitudes(obs_range, abs_mag_sun)
+        #mr_obs = cf.convert_to_magnitudes(obs_range, abs_mag_sun)
 
         #save on datablock
         block.put_double_array_1d('observable_function' + suffix0,'obs_med',obs_h)


### PR DESCRIPTION
Removes `pipeline`, `abs_mag_sun`, renames halo mass and bias functions, deals with `colossus` and `hmf` warnings, removes extrapolation of HOD far beyond valid ranges